### PR TITLE
Extract Role from Group::Membership for better encapsulation

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,5 +13,5 @@ group = ::Group::Group.create(
 ::Group::Membership.create(
   user: ::Group::User.find(user.id),
   group: group,
-  role: ::Group::Membership::ROLES[:admin]
+  role: :admin
 )

--- a/engines/account/app/controllers/account/api/v1/signups_controller.rb
+++ b/engines/account/app/controllers/account/api/v1/signups_controller.rb
@@ -8,7 +8,7 @@ module Account
         # POST /api/v1/signups
         #
         def create
-          signup = SignupService.new().create!(signup_create_params[:email])
+          signup = SignupService.new.create!(signup_create_params[:email])
 
           if signup.valid? && signup.persisted?
             render status: :created, nothing: true
@@ -31,7 +31,7 @@ module Account
         # POST /api/v1/signups/complete/:token
         #
         def complete
-          user = SignupService.new().complete!(@signup, signup_complete_params)
+          user = SignupService.new.complete!(@signup, signup_complete_params)
 
           if user.valid? && user.persisted?
             render json: UserSerializer.new(user)

--- a/engines/group/app/models/group/group.rb
+++ b/engines/group/app/models/group/group.rb
@@ -6,11 +6,11 @@ module Group
     has_many :memberships, dependent: :destroy
     has_many :users, through: :memberships
     has_many :admins,
-      -> { where "memberships.role = #{ Membership::ROLES[:admin] }" },
+      -> { where "memberships.role = #{Role.new(:admin).index}" },
     through: :memberships,
       source: :user
     has_many :waiters,
-      -> { where "memberships.role = #{ Membership::ROLES[:waiting] }" },
+      -> { where "memberships.role = #{Role.new(:waiters).index}" },
     through: :memberships,
       source: :user
 

--- a/engines/group/app/models/group/membership.rb
+++ b/engines/group/app/models/group/membership.rb
@@ -3,13 +3,20 @@ module Group
 
     self.table_name = :memberships
 
-    ROLES = { admin: 1, member: 2, waiting: 3 }
-
     belongs_to :group
     belongs_to :user
 
     validates :group, :user, :role, presence: true
-    validates :role, inclusion: { in: ROLES.values }
     validates :user_id, uniqueness: { scope: :group_id }
+
+    def role=(value)
+      @role = Role.new(value)
+      self[:role] = @role.index
+      @role
+    end
+
+    def role
+      @role ||= Role.from_index(self[:role])
+    end
   end
 end

--- a/engines/group/app/models/role.rb
+++ b/engines/group/app/models/role.rb
@@ -1,0 +1,52 @@
+class Role
+  include Comparable
+
+  attr_reader :index
+
+  class InvalidRole < ArgumentError; end
+
+  VALUES = { admin: 1, member: 2, waiting: 3 }
+
+  def self.from_index(index)
+    case index
+    when 1
+      new(:admin)
+    when 2
+      new(:member)
+    when 3
+      new(:waiting)
+    end
+  end
+
+  def initialize(role)
+    validate!(role)
+
+    @role = role
+    @index = VALUES[role]
+  end
+
+  def validate!(role)
+    return if VALUES.key?(role)
+    raise InvalidRole, 'No supported role'
+  end
+
+  def <=>(other)
+    other.to_s <=> to_s
+  end
+
+  def hash
+    role.hash
+  end
+
+  def eql?(other)
+    to_s == other.to_s
+  end
+
+  def to_s
+    role.to_s
+  end
+
+  private
+
+  attr_reader :role
+end

--- a/engines/group/app/policies/group/group_policy.rb
+++ b/engines/group/app/policies/group/group_policy.rb
@@ -14,7 +14,7 @@ module Group
       Membership.where(
         group: record,
         user: user,
-        role: [Membership::ROLES[:admin], Membership::ROLES[:member]]
+        role: [Role.new(:admin).index, Role.new(:member).index]
       ).any?
     end
 
@@ -22,7 +22,7 @@ module Group
       Membership.where(
         group: record,
         user: user,
-        role: Membership::ROLES[:admin]
+        role: Role.new(:admin).index
       ).any?
     end
 
@@ -30,7 +30,7 @@ module Group
       Membership.where(
         group: record,
         user: user,
-        role: Membership::ROLES[:admin]
+        role: Role.new(:admin).index
       ).any?
     end
   end

--- a/engines/group/app/policies/group/membership_policy.rb
+++ b/engines/group/app/policies/group/membership_policy.rb
@@ -11,15 +11,27 @@ module Group
     end
 
     def create?
-      Membership.where(group: record.group, user: user, role: Membership::ROLES[:admin]).any?
+      Membership.where(
+        group: record.group,
+        user: user,
+        role: Role.new(:admin).index
+      ).any?
     end
 
     def update?
-      Membership.where(group: record.group, user: user, role: Membership::ROLES[:admin]).any?
+      Membership.where(
+        group: record.group,
+        user: user,
+        role: Role.new(:admin).index
+      ).any?
     end
 
     def destroy?
-      Membership.where(group: record.group, user: user, role: Membership::ROLES[:admin]).any?
+      Membership.where(
+        group: record.group,
+        user: user,
+        role: Role.new(:admin).index
+      ).any?
     end
   end
 end

--- a/engines/group/app/services/group/group_creator.rb
+++ b/engines/group/app/services/group/group_creator.rb
@@ -30,7 +30,7 @@ module Group
     def add_creator_as_group_admin
       group.memberships.create(
         user: creator,
-        role: ::Group::Membership::ROLES[:admin]
+        role: :admin
       )
     end
   end

--- a/engines/onboarding/app/policies/onboarding/group_policy.rb
+++ b/engines/onboarding/app/policies/onboarding/group_policy.rb
@@ -7,7 +7,11 @@ module Onboarding
     end
 
     def bulk?
-      Membership.where(group: record, user: user, role: Membership::ROLES[:admin]).any?
+      Membership.where(
+        group: record,
+        user: user,
+        role: Role.new(:admin).index
+      ).any?
     end
   end
 end

--- a/engines/onboarding/app/policies/onboarding/invitation_policy.rb
+++ b/engines/onboarding/app/policies/onboarding/invitation_policy.rb
@@ -7,7 +7,11 @@ module Onboarding
     end
 
     def create?
-      Membership.where(group: record.group, user: user, role: Membership::ROLES[:admin]).any?
+      Membership.where(
+        group: record.group,
+        user: user,
+        role: Role.new(:admin).index
+      ).any?
     end
   end
 end

--- a/engines/onboarding/app/services/onboarding/invitation_service.rb
+++ b/engines/onboarding/app/services/onboarding/invitation_service.rb
@@ -91,7 +91,7 @@ module Onboarding
       group = ::Group::Group.find(group_id)
       group.memberships.create(
         user_id: user_id,
-        role: ::Group::Membership::ROLES[:member]
+        role: :member
       )
     end
 


### PR DESCRIPTION
I'm trying to hide the details of the roles from Membership's consumers, by making roles explicit using a value object. I always thought that dealing with roles by exposing an internal hash is not only annoying but also a mistake.

We should be aware of these things and not leak implementation details when possible.