### PR TITLE
Add frontend base URL

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,7 +15,6 @@ Katuma::Application.configure do
   config.action_controller.perform_caching = false
 
   # ActionMailer configuration
-  config.action_mailer.default_url_options = { host: 'localhost', port: '3000' }
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :file
 

--- a/engines/account/app/mailers/account/signup_mailer.rb
+++ b/engines/account/app/mailers/account/signup_mailer.rb
@@ -13,11 +13,9 @@ module Account
 
     private
 
-    # TODO Find a way to manage express URLs
-    #
     # @return [String]
     def confirm_url
-      "http://10.0.3.70:8000/signup/complete/#{@signup.token}"
+      "#{::Shared::FrontendUrl.base_url}/signup/complete/#{@signup.token}"
     end
   end
 end

--- a/engines/onboarding/app/mailers/onboarding/invitation_mailer.rb
+++ b/engines/onboarding/app/mailers/onboarding/invitation_mailer.rb
@@ -14,11 +14,9 @@ module Onboarding
 
     private
 
-    # TODO Find a way to manage express URLs
-    #
     # @return [String]
     def accept_url
-      "http://localhost:8000/invitation/accept/#{@invitation.token}"
+      "#{::Shared::FrontendUrl.base_url}/invitation/accept/#{@invitation.token}"
     end
   end
 end

--- a/engines/onboarding/app/mailers/onboarding/user_mailer.rb
+++ b/engines/onboarding/app/mailers/onboarding/user_mailer.rb
@@ -4,7 +4,7 @@ module Onboarding
 
     def welcome_email(user)
       @user = user
-      @url  = 'http://www.katuma.org'
+      @url  = ::Shared::FrontendUrl.base_url
       mail(to: @user.email, subject: 'Welcome to katuma.org!')
     end
   end

--- a/engines/shared/lib/shared/engine.rb
+++ b/engines/shared/lib/shared/engine.rb
@@ -2,6 +2,8 @@ module Shared
   class Engine < ::Rails::Engine
     isolate_namespace Shared
 
+    config.autoload_paths += %W(#{config.root}/lib)
+
     initializer "shared.assets.precompile" do |app|
       app.config.assets.precompile += %w(application.css application.js)
     end

--- a/engines/shared/lib/shared/frontend_url.rb
+++ b/engines/shared/lib/shared/frontend_url.rb
@@ -1,0 +1,39 @@
+module Shared
+  module FrontendUrl
+    # The environment variable will allow to override the default host,
+    # useful while running development environments in containers
+    DEVELOPMENT_HOST = ENV['DEVELOPMENT_HOST'] || 'localhost'
+    DEVELOPMENT_PORT = 8000
+
+    def self.base_url
+      "#{protocol}://#{host}"
+    end
+
+    private
+
+    # HTTP protocol
+    #
+    # TODO: implement SSL and switch to https in production
+    #
+    # @return [String]
+    def self.protocol
+      'http'
+    end
+
+    # Domain name
+    #
+    # @return [String]
+    def self.host
+      return development_host if Rails.env.development?
+
+      'alfa.katuma.org'
+    end
+
+    # Domain name for developmnent environment
+    #
+    # @return [String]
+    def self.development_host
+      "#{DEVELOPMENT_HOST}:#{DEVELOPMENT_PORT}"
+    end
+  end
+end


### PR DESCRIPTION
With this module we'll be able to create frontend URLs:

 - in production: `http://alfa.katuma.org`
 - in development running inside a container/VM: content of `DEVELOPMENT_HOST` environment variable (ex. `http://10.0.3.133`)
 - in development running directly in the host: `localhost`

In the future we'll add more options when we'll have more environments.

I deployed this on http://alfa.katuma.org if you want to give it a try!

![](https://media.giphy.com/media/Lny6Rw04nsOOc/giphy.gif)