### PR TITLE
Using init.d scripts to manage unicorn and sidekiq on remote machine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,6 @@ gemspec path: 'engines/suppliers'
 gemspec path: 'engines/onboarding'
 
 gem 'mina', '0.3.7'
-gem 'mina-unicorn', '0.3.0', require: false
 
 gem 'autoprefixer-rails', '6.1.0.1'
 gem 'sass-rails', '5.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,6 @@ GEM
     mina (0.3.7)
       open4 (~> 1.3.4)
       rake
-    mina-unicorn (0.3.0)
     mini_portile (0.6.2)
     minitest (5.8.3)
     nokogiri (1.6.6.4)
@@ -232,7 +231,6 @@ DEPENDENCIES
   haml (= 4.0.7)
   landing!
   mina (= 0.3.7)
-  mina-unicorn (= 0.3.0)
   oat (= 0.4.6)
   onboarding!
   pg (= 0.18.3)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,8 @@
 require 'mina/bundler'
 require 'mina/rails'
 require 'mina/git'
-require 'mina/unicorn'
+load File.expand_path("../../lib/tasks/unicorn.rake", __FILE__)
+load File.expand_path("../../lib/tasks/sidekiq.rake", __FILE__)
 
 set :domain, 'alfa.katuma.org'
 set :deploy_to, '/opt/app/katuma'
@@ -15,9 +16,8 @@ set :shared_paths, ['config/database.yml', 'config/secrets.yml', 'log']
 # Unicorn stuff
 set :unicorn_pid, '/var/run/unicorn/unicorn.pid'
 
-# Optional settings:
+# SSH settings
 set :user, 'ubuntu'
-# SSH port number.
 set :port, '22666'
 set :forward_agent, true
 
@@ -43,6 +43,7 @@ task :deploy => :environment do
       queue "mkdir -p #{deploy_to}/#{current_path}/tmp/"
       queue "touch #{deploy_to}/#{current_path}/tmp/restart.txt"
       invoke :'unicorn:restart'
+      invoke :'sidekiq:restart'
     end
   end
 end

--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -1,0 +1,16 @@
+namespace :sidekiq do
+  desc "Starts Sidekiq init.d script"
+  task :start => :environment do
+    queue "sudo /etc/init.d/sidekiq_katuma start"
+  end
+
+  desc "Stops Sidekiq init.d script"
+  task :stop => :environment do
+    queue "sudo /etc/init.d/sidekiq_katuma stop"
+  end
+
+  desc "Restarts Sidekiq init.d script"
+  task :restart => :environment do
+    queue "sudo /etc/init.d/sidekiq_katuma restart"
+  end
+end

--- a/lib/tasks/unicorn.rake
+++ b/lib/tasks/unicorn.rake
@@ -1,0 +1,16 @@
+namespace :unicorn do
+  desc "Starts Unicorn init.d script"
+  task :start => :environment do
+    queue "sudo /etc/init.d/unicorn_katuma start"
+  end
+
+  desc "Stops Unicorn init.d script"
+  task :stop => :environment do
+    queue "sudo /etc/init.d/unicorn_katuma stop"
+  end
+
+  desc "Restarts Unicorn init.d script"
+  task :restart => :environment do
+    queue "sudo /etc/init.d/unicorn_katuma restart"
+  end
+end


### PR DESCRIPTION
We should have only one entry point to manage services on production machines: `init.d` scripts

![](https://media.giphy.com/media/cp04NsIO35VCw/giphy.gif)