### PR TITLE
Do not require emails on bulk invitations

### DIFF
--- a/engines/onboarding/app/controllers/onboarding/api/v1/invitations_controller.rb
+++ b/engines/onboarding/app/controllers/onboarding/api/v1/invitations_controller.rb
@@ -98,6 +98,7 @@ module Onboarding
         #
         def bulk_params
           params.require(:group_id)
+          params.require(:emails)
           params.permit(:group_id, :emails)
         end
 

--- a/engines/onboarding/app/controllers/onboarding/api/v1/invitations_controller.rb
+++ b/engines/onboarding/app/controllers/onboarding/api/v1/invitations_controller.rb
@@ -98,7 +98,6 @@ module Onboarding
         #
         def bulk_params
           params.require(:group_id)
-          params.require(:emails)
           params.permit(:group_id, :emails)
         end
 

--- a/engines/onboarding/app/controllers/onboarding/application_controller.rb
+++ b/engines/onboarding/app/controllers/onboarding/application_controller.rb
@@ -2,5 +2,6 @@ module Onboarding
   class ApplicationController < ActionController::Base
     include Shared::Controller::Authentication
     include Shared::Controller::Authorization
+    include Shared::Controller::ParameterMissingException
   end
 end

--- a/engines/onboarding/config/locales/es.yml
+++ b/engines/onboarding/config/locales/es.yml
@@ -3,5 +3,4 @@ es:
     invitation:
       bulk:
         errors:
-          empty: 'Al menos debes escribir un email'
           invalid: 'Ninguno de los emails que has escrito es valido. Por favor revisalo.'

--- a/engines/shared/app/controllers/shared/controller/parameter_missing_exception.rb
+++ b/engines/shared/app/controllers/shared/controller/parameter_missing_exception.rb
@@ -7,7 +7,6 @@ module Shared
         rescue_from ActionController::ParameterMissing, with: :missing_parameter
       end
 
-
       protected
 
       def missing_parameter(error)
@@ -26,7 +25,6 @@ module Shared
           )
         }
       end
-
     end
   end
 end

--- a/engines/shared/app/controllers/shared/controller/parameter_missing_exception.rb
+++ b/engines/shared/app/controllers/shared/controller/parameter_missing_exception.rb
@@ -1,0 +1,32 @@
+module Shared
+  module Controller
+    module ParameterMissingException
+      extend ::ActiveSupport::Concern
+
+      included do
+        rescue_from ActionController::ParameterMissing, with: :missing_parameter
+      end
+
+
+      protected
+
+      def missing_parameter(error)
+        render(
+          status: :bad_request,
+          json: { errors: error_message_for_required_field(error.param) }
+        )
+      end
+
+      def error_message_for_required_field(field)
+        {
+          field => t("#{controller_name}.#{action_name}.#{field}",
+            field: field,
+            default: [:generic],
+            scope: :missing_param
+          )
+        }
+      end
+
+    end
+  end
+end

--- a/engines/shared/config/locales/es.yml
+++ b/engines/shared/config/locales/es.yml
@@ -1,0 +1,6 @@
+es:
+  missing_param:
+    generic: el campo %{field} no puede quedar en blanco
+    invitations:
+      bulk:
+        emails: 'Al menos debes escribir un email'


### PR DESCRIPTION
## WAT
Not necessary validate presence of `emails` on that layer. Already validated later. Also validating in that moment do not return the error for UI:
![image](https://cloud.githubusercontent.com/assets/49499/12223574/8cf4c50c-b7db-11e5-9166-ff524b59b5ae.png)
