### PR TITLE
Remove user checking from invitation show

### DIFF
--- a/engines/onboarding/app/controllers/onboarding/api/v1/invitations_controller.rb
+++ b/engines/onboarding/app/controllers/onboarding/api/v1/invitations_controller.rb
@@ -61,8 +61,6 @@ module Onboarding
         # GET /api/v1/invitations/:token
         #
         def show
-          head :bad_request if current_user
-
           render status: :ok, json: { email: @invitation.email }
         end
 


### PR DESCRIPTION
## WAT
I removed user checking on `invitation#show` end point. This was raising this issue https://github.com/coopdevs/katuma/issues/78

Finally I decided that is not API responsibility in this case if there is in the UI a user logged. Is better delegate that check to UI application.

I'm doing that in this front end PR: https://github.com/coopdevs/katuma-web/pull/9

Thoughts?