### PR TITLE
Remove unused restart.txt touch

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -40,8 +40,6 @@ task :deploy => :environment do
     invoke :'deploy:cleanup'
 
     to :launch do
-      queue "mkdir -p #{deploy_to}/#{current_path}/tmp/"
-      queue "touch #{deploy_to}/#{current_path}/tmp/restart.txt"
       invoke :'unicorn:restart'
       invoke :'sidekiq:restart'
     end


### PR DESCRIPTION
### WAT
`restart.txt` is only used by Passenger... that we don't use :fire: :fire: :fire: 

### GIF
![](https://media.giphy.com/media/3o6gbbt9uYNcOtJ29y/giphy.gif)