### PR TITLE
Add HttpResourceLinks library

### DIFF
--- a/engines/group/app/controllers/group/api/v1/groups_controller.rb
+++ b/engines/group/app/controllers/group/api/v1/groups_controller.rb
@@ -81,19 +81,7 @@ module Group
         def add_side_effects_links
           return unless @side_effects.any?
 
-          links = @side_effects.flatten.map do |side_effect|
-            "<#{api_link(side_effect)}>; rel=\"created\" type=\"#{model_type(side_effect)}\""
-          end.join(', ')
-
-          response.headers['Link'] = links
-        end
-
-        def api_link(side_effect)
-          "http://localhost:8000/api/v1/#{model_type(side_effect).downcase.pluralize}/#{side_effect.id}"
-        end
-
-        def model_type(side_effect)
-          side_effect.class.name
+          response.headers['Link'] = ::Shared::HttpResourceLinks.build(@side_effects.flatten.uniq)
         end
       end
     end

--- a/engines/shared/lib/shared/http_resource_links.rb
+++ b/engines/shared/lib/shared/http_resource_links.rb
@@ -1,0 +1,16 @@
+module Shared
+  module HttpResourceLinks
+    module_function
+
+    # Returns the HTTP resource links for the given ActiveRecord collection
+    #
+    # The generated link is RFC 5988 compliant
+    # for more info please visit https://www.w3c.org/wiki/LinkHeader
+    #
+    # @param objects [Array<ActiveRecord::Base>]
+    # @return [String]
+    def build(objects)
+      Collection.new(objects).links
+    end
+  end
+end

--- a/engines/shared/lib/shared/http_resource_links/collection.rb
+++ b/engines/shared/lib/shared/http_resource_links/collection.rb
@@ -1,0 +1,22 @@
+module Shared
+  module HttpResourceLinks
+    class Collection
+
+      # @param objects [Array<ActiveRecord::Base>]
+      def initialize(objects)
+        @collection = objects.map { |object| Item.new(object) }
+      end
+
+      # Returns the resource link header
+      #
+      # @return [String]
+      def links
+        collection.map(&:link).join(', ')
+      end
+
+      private
+
+      attr_accessor :collection
+    end
+  end
+end

--- a/engines/shared/lib/shared/http_resource_links/item.rb
+++ b/engines/shared/lib/shared/http_resource_links/item.rb
@@ -1,0 +1,42 @@
+module Shared
+  module HttpResourceLinks
+    class Item
+      API_VERSION = 1
+
+      attr_accessor :object
+
+      # @param object [ActiveRecord::Base]
+      def initialize(object)
+        @object = object
+      end
+
+      # Returns the link header
+      #
+      # @return [String]
+      def link
+        "<#{api_link}>; rel=\"#{relation}\" type=\"#{object.class.name}\""
+      end
+
+      private
+
+      # Returns an API uri for the given model
+      #
+      # @return [String] resource api url
+      def api_link
+        "#{::Shared::FrontendUrl.base_url}/api/#{API_VERSION}/#{object.model_name.route_key}/#{object.id}"
+      end
+
+      # @return [String]
+      def relation
+        return 'created' if new_record?
+
+        'updated'
+      end
+
+      # @return [Boolean]
+      def new_record?
+        object.previous_changes['id'] == [nil, object.id]
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WAT
We're abstracting the resource link generation to a library. This is a first step toward abstracting the side effects thing to a controller mixin.

### Why!?
Right now we're only using side effects and resource links in `Group::Group` creation to communicate to the client that its POST request generated a side effect: a new `Group::Membership`. But we'll need to create more side effects while creating other resources too.

### Example
As a response header to the `POST /api/v1/groups` request:
```
link:<http://10.0.3.133:8000/api/1/memberships/5>; rel="created" type="Group::Membership"
```

### GIF
![](http://45.media.tumblr.com/0aa3c10d7eeed64f4167e6c98f61ef41/tumblr_nl1yenylAh1snwkluo1_1280.gif)