### PR TITLE
Fix bundler weird issue on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,8 @@ branches:
   only:
     - develop
 
+before_install:
+  - gem update bundler
+
 before_script:
   - "bundle exec rake db:setup"


### PR DESCRIPTION
### WAT
We're getting the following error in Travis CI:
```
NoMethodError: undefined method `spec' for nil:NilClass

An error occurred while installing group (0.0.1), and Bundler cannot continue.

Make sure that `gem install group -v '0.0.1'` succeeds before bundling.

The command "eval bundle install --jobs=3 --retry=3 --deployment" failed 3 times.
```
It seems related to [this](https://github.com/steakunderscore/screencap/commit/d5b8a0e17ecd40a5fa38faaa71e08d916d591995)

### GIF
![](https://media.giphy.com/media/AtMYLeBYYFWEM/giphy.gif)