### PR TITLE
Fix suppliers resource

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,7 @@ joanin = ::Account::User.create!(
   first_name: 'Joanin',
   last_name: 'Cerea',
   username: 'joanin',
-  password: 'kakaka22'
+  password: 'papapa22'
 )
 
 frida = ::Account::User.create!(
@@ -13,7 +13,7 @@ frida = ::Account::User.create!(
   first_name: 'Frida',
   last_name: 'Fola',
   username: 'frida',
-  password: 'kakaka22'
+  password: 'papapa22'
 )
 
 # Groups

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,6 @@
-user = ::Account::User.create(
+# Users
+
+joanin = ::Account::User.create!(
   email: 'joanin@katuma.org',
   first_name: 'Joanin',
   last_name: 'Cerea',
@@ -6,12 +8,66 @@ user = ::Account::User.create(
   password: 'kakaka22'
 )
 
-group = ::BasicResources::Group.create(
+frida = ::Account::User.create!(
+  email: 'frida@katuma.org',
+  first_name: 'Frida',
+  last_name: 'Fola',
+  username: 'frida',
+  password: 'kakaka22'
+)
+
+# Groups
+
+tomatika = ::BasicResources::Group.create!(
   name: 'Tomatika'
 )
 
-::BasicResources::Membership.create(
-  user_id: user.id,
-  basic_resource_group_id: group.id,
+::BasicResources::Membership.create!(
+  user_id: joanin.id,
+  basic_resource_group_id: tomatika.id,
   role: ::BasicResources::Membership::ROLES[:admin]
 )
+
+::BasicResources::Membership.create!(
+  user_id: frida.id,
+  basic_resource_group_id: tomatika.id,
+  role: ::BasicResources::Membership::ROLES[:member]
+)
+
+cabas = ::BasicResources::Group.create!(
+  name: 'Cabas'
+)
+
+::BasicResources::Membership.create!(
+  user_id: frida.id,
+  basic_resource_group_id: cabas.id,
+  role: ::BasicResources::Membership::ROLES[:admin]
+)
+
+# Producers
+
+jaume = ::BasicResources::Producer.new(
+  name: 'El Jaume',
+  email: 'jaume@eljaume.coop',
+  address: 'c/ de les peras, 33, Barbera del Valles'
+)
+::BasicResources::ProducerCreator.new(
+  producer: jaume,
+  creator: joanin,
+  group: tomatika
+).create!
+::Suppliers::Supplier.create!(
+  group_id: tomatika.id,
+  producer_id: jaume.id
+)
+
+prueba = ::BasicResources::Producer.new(
+  name: 'Productor de prueba',
+  email: 'test@katuma.org',
+  address: 'c/ de las pruebas, Barcelona'
+)
+::BasicResources::ProducerCreator.new(
+  producer: prueba,
+  creator: joanin,
+  group: tomatika
+).create!

--- a/engines/basic_resources/app/controllers/basic_resources/api/v1/producers_controller.rb
+++ b/engines/basic_resources/app/controllers/basic_resources/api/v1/producers_controller.rb
@@ -47,7 +47,7 @@ module BasicResources
           else
             render(
               status: :bad_request,
-              json: { errors: producer.errors.messages }
+              json: { errors: @producer.errors.messages }
             )
           end
         end

--- a/engines/basic_resources/app/controllers/basic_resources/api/v1/producers_controller.rb
+++ b/engines/basic_resources/app/controllers/basic_resources/api/v1/producers_controller.rb
@@ -34,7 +34,7 @@ module BasicResources
           else
             render(
               status: :bad_request,
-              json: producer.errors.to_json
+              json: { errors: producer.errors.messages }
             )
           end
         end
@@ -47,7 +47,7 @@ module BasicResources
           else
             render(
               status: :bad_request,
-              json: producer.errors.to_json
+              json: { errors: producer.errors.messages }
             )
           end
         end

--- a/engines/basic_resources/spec/controllers/basic_resources/api/v1/producers_controller_spec.rb
+++ b/engines/basic_resources/spec/controllers/basic_resources/api/v1/producers_controller_spec.rb
@@ -132,9 +132,14 @@ module BasicResources
 
                 subject { JSON.parse(response.body) }
 
-                its(:size) { is_expected.to eq(2) }
-                it { is_expected.to include('email' => ["can't be blank"]) }
-                it { is_expected.to include('address' => ["can't be blank"]) }
+                it do
+                  is_expected.to include(
+                    'errors' => {
+                      'email' => ["can't be blank"],
+                      'address' => ["can't be blank"]
+                    }
+                  )
+                end
               end
             end
 
@@ -181,14 +186,41 @@ module BasicResources
               end
 
               context 'when the user is a producer admin' do
-                it_behaves_like 'a successful request'
+                context 'with valid parameters' do
+                  it_behaves_like 'a successful request'
 
-                describe 'its body' do
-                  before { put :update, params }
+                  describe 'its body' do
+                    before { put :update, params }
 
-                  subject { JSON.parse(response.body) }
+                    subject { JSON.parse(response.body) }
 
-                  it { is_expected.to include(JSON.parse(params.to_json)) }
+                    it { is_expected.to include(JSON.parse(params.to_json)) }
+                  end
+                end
+
+                context 'with not valid parameters' do
+                  let(:params) do
+                    {
+                      id: producer.id,
+                      email: nil
+                    }
+                  end
+
+                  it_behaves_like 'a bad request'
+
+                  describe 'its body' do
+                    before { put :update, params }
+
+                    subject { JSON.parse(response.body) }
+
+                    it do
+                      is_expected.to include(
+                        'errors' => {
+                          'email' => ["can't be blank"]
+                        }
+                      )
+                    end
+                  end
                 end
               end
 

--- a/engines/suppliers/app/controllers/suppliers/api/v1/suppliers_controller.rb
+++ b/engines/suppliers/app/controllers/suppliers/api/v1/suppliers_controller.rb
@@ -5,7 +5,6 @@ module Suppliers
         before_action :authenticate
         before_action :load_supplier, only: [:show, :update, :destroy]
         before_action :load_group, only: [:index, :create]
-        before_action :load_producer, only: [:create]
 
         # GET /api/v1/suppliers?group_id=
         #
@@ -28,7 +27,7 @@ module Suppliers
         def create
           supplier = Supplier.new(
             group: @group,
-            producer: @producer
+            producer_id: supplier_params[:producer_id]
           )
 
           if supplier.save
@@ -36,7 +35,7 @@ module Suppliers
           else
             render(
               status: :bad_request,
-              json: supplier.errors
+              json: { errors: supplier.errors.messages }
             )
           end
         end
@@ -71,14 +70,6 @@ module Suppliers
           return head :not_found unless @group
 
           authorize @group
-        end
-
-        def load_producer
-          @producer = Producer.find_by_id(supplier_params[:producer_id])
-
-          return head :not_found unless @producer
-
-          authorize @producer
         end
       end
     end

--- a/engines/suppliers/app/controllers/suppliers/api/v1/suppliers_controller.rb
+++ b/engines/suppliers/app/controllers/suppliers/api/v1/suppliers_controller.rb
@@ -7,22 +7,20 @@ module Suppliers
         before_action :load_group, only: [:index, :create]
         before_action :load_producer, only: [:create]
 
-        # GET /api/v1/suppliers
+        # GET /api/v1/suppliers?group_id=
         #
         # You must pass `group_id` param as filter
         #
-        # TODO: Deal better with finders, filters and collections
-        #
         def index
-          suppliers = ::Suppliers::Supplier.where(group_id: @group.id)
+          suppliers = Supplier.where(group_id: @group.id)
 
-          render json: ::Suppliers::SuppliersSerializer.new(suppliers)
+          render json: SuppliersSerializer.new(suppliers)
         end
 
         # GET /api/v1/suppliers/:id
         #
         def show
-          render json: ::Suppliers::SupplierSerializer.new(@supplier)
+          render json: SupplierSerializer.new(@supplier)
         end
 
         # POST /api/v1/suppliers
@@ -33,7 +31,7 @@ module Suppliers
             producer: @producer
           )
 
-          if supplier.valid? && supplier.save
+          if supplier.save
             render json: SupplierSerializer.new(supplier)
           else
             render(
@@ -68,7 +66,7 @@ module Suppliers
         end
 
         def load_group
-          @group = ::Suppliers::Group.find_by_id(supplier_params[:group_id])
+          @group = Group.find_by_id(supplier_params[:group_id])
 
           return head :not_found unless @group
 
@@ -76,7 +74,7 @@ module Suppliers
         end
 
         def load_producer
-          @producer = ::Suppliers::Producer.find_by_id(supplier_params[:producer_id])
+          @producer = Producer.find_by_id(supplier_params[:producer_id])
 
           return head :not_found unless @producer
 

--- a/engines/suppliers/app/controllers/suppliers/api/v1/suppliers_controller.rb
+++ b/engines/suppliers/app/controllers/suppliers/api/v1/suppliers_controller.rb
@@ -1,0 +1,88 @@
+module Suppliers
+  module Api
+    module V1
+      class SuppliersController < ApplicationController
+        before_action :authenticate
+        before_action :load_supplier, only: [:show, :update, :destroy]
+        before_action :load_group, only: [:index, :create]
+        before_action :load_producer, only: [:create]
+
+        # GET /api/v1/suppliers
+        #
+        # You must pass `group_id` param as filter
+        #
+        # TODO: Deal better with finders, filters and collections
+        #
+        def index
+          suppliers = ::Suppliers::Supplier.where(group_id: @group.id)
+
+          render json: ::Suppliers::SuppliersSerializer.new(suppliers)
+        end
+
+        # GET /api/v1/suppliers/:id
+        #
+        def show
+          render json: ::Suppliers::SupplierSerializer.new(@supplier)
+        end
+
+        # POST /api/v1/suppliers
+        #
+        def create
+          supplier = Supplier.new(
+            group: @group,
+            producer: @producer
+          )
+
+          if supplier.valid? && supplier.save
+            render json: SupplierSerializer.new(supplier)
+          else
+            render(
+              status: :bad_request,
+              json: supplier.errors
+            )
+          end
+        end
+
+        # DELETE /api/v1/suppliers/:id
+        #
+        def destroy
+          if @supplier.destroy
+            head :no_content
+          else
+            head :bad_request
+          end
+        end
+
+        private
+
+        def supplier_params
+          params.permit(:group_id, :producer_id)
+        end
+
+        def load_supplier
+          @supplier = Supplier.find_by_id(params[:id])
+
+          return head :not_found unless @supplier
+
+          authorize @supplier.group
+        end
+
+        def load_group
+          @group = ::Suppliers::Group.find_by_id(supplier_params[:group_id])
+
+          return head :not_found unless @group
+
+          authorize @group
+        end
+
+        def load_producer
+          @producer = ::Suppliers::Producer.find_by_id(supplier_params[:producer_id])
+
+          return head :not_found unless @producer
+
+          authorize @producer
+        end
+      end
+    end
+  end
+end

--- a/engines/suppliers/app/policies/suppliers/group_policy.rb
+++ b/engines/suppliers/app/policies/suppliers/group_policy.rb
@@ -13,7 +13,11 @@ module Suppliers
     end
 
     def create?
-      false
+      Membership.where(
+        basic_resource_group_id: record.id,
+        user_id: user.id,
+        role: Membership::ROLES[:admin]
+      ).any?
     end
 
     def update?
@@ -21,7 +25,7 @@ module Suppliers
     end
 
     def destroy?
-      false
+      create?
     end
   end
 end

--- a/engines/suppliers/app/policies/suppliers/producer_policy.rb
+++ b/engines/suppliers/app/policies/suppliers/producer_policy.rb
@@ -6,8 +6,11 @@ module Suppliers
         producer_is_provider_of_any_group?
     end
 
+    # You don't need permissions at Producer level to
+    # add a Producer as a Supplier to a Group, for now...
+    #
     def create?
-      false
+      true
     end
 
     def update?

--- a/engines/suppliers/spec/controllers/suppliers/api/v1/suppliers_controller_spec.rb
+++ b/engines/suppliers/spec/controllers/suppliers/api/v1/suppliers_controller_spec.rb
@@ -1,0 +1,244 @@
+require 'rails_helper'
+require_relative '../../../../../../../spec/support/shared_examples/controllers.rb'
+require_relative '../../../../../../../spec/support/authentication.rb'
+
+module Suppliers
+  module Api
+    module V1
+      describe SuppliersController do
+        routes { Engine.routes }
+
+        context 'Not authenticaded user' do
+          describe 'GET #index' do
+            subject { get :index }
+
+            it_behaves_like 'an unauthorized request'
+          end
+
+          describe 'GET #show' do
+            subject { get :show, id: 666 }
+
+            it_behaves_like 'an unauthorized request'
+          end
+
+          describe 'POST #create' do
+            subject { post :create, name: 'ciola' }
+
+            it_behaves_like 'an unauthorized request'
+          end
+
+          describe 'DELETE #destroy' do
+            subject { delete :destroy, id: 666 }
+
+            it_behaves_like 'an unauthorized request'
+          end
+        end
+
+        context 'Authenticated user' do
+          let(:user) do
+            FactoryGirl.create(:user)
+          end
+          let(:group_user) { ::Group::User.find(user.id) }
+          let(:suppliers_user) { User.find(user.id) }
+          let(:group_membership) do
+            FactoryGirl.create(
+              :membership,
+              user: group_user,
+              role: ::Group::Membership::ROLES[:admin]
+            )
+          end
+          let(:group) do
+            ::Suppliers::Group.find(group_membership.group.id)
+          end
+          let(:producer_for_group) do
+            FactoryGirl.build(:producer, name: 'Related to group')
+          end
+          let(:producer_for_user) do
+            FactoryGirl.build(:producer, name: 'Related to user')
+          end
+          let(:producer) do
+            ::Producers::ProducerCreator.new(
+              producer: producer_for_group,
+              creator: suppliers_user,
+              group: ::Producers::Group.find(group.id)
+            ).create
+
+            Producer.last
+          end
+
+          before { authenticate_as suppliers_user }
+
+          describe 'GET #index' do
+            let!(:supplier) do
+              FactoryGirl.create(
+                :supplier,
+                group: group,
+                producer: producer
+              )
+            end
+
+            subject { get :index, group_id: group.id }
+
+            it_behaves_like 'a successful request'
+
+            describe 'its body' do
+              before { get :index, group_id: group.id }
+
+              subject { JSON.parse(response.body) }
+
+              its(:size) { is_expected.to eq(1) }
+              it { is_expected.to include(JSON.parse(supplier.to_json)) }
+            end
+          end
+
+          describe 'GET #show' do
+            let(:supplier) do
+              FactoryGirl.create(
+                :supplier,
+                producer: producer,
+                group: group
+              )
+            end
+            let(:params) { { id: supplier.id } }
+
+            subject { get :show, params }
+
+            context 'requesting a non existent supplier' do
+              let(:supplier) { instance_double(Supplier, id: 666) }
+
+              it_behaves_like 'a not found request'
+            end
+
+            xcontext 'requesting a supplier which producer is associated to a user' do
+            end
+
+            context 'requesting a supplier which producer is associated to a group' do
+              it_behaves_like 'a successful request'
+
+              describe 'its body' do
+                before { get :show, params }
+
+                subject { JSON.parse(response.body) }
+
+                it { is_expected.to include(JSON.parse(supplier.to_json)) }
+              end
+
+              context 'when the user is not a group admin' do
+                before do
+                  group_membership.role = ::Group::Membership::ROLES[:member]
+                  group_membership.save!
+                end
+
+                it_behaves_like 'a successful request'
+              end
+            end
+
+            context 'requesting a supplier not associated to the current user' do
+              let(:suppliers_user) do
+                user = FactoryGirl.create(:user)
+                User.find(user.id)
+              end
+
+              it_behaves_like 'a forbidden request'
+            end
+          end
+
+          describe 'POST #create' do
+            let(:params) do
+              {
+                group_id: group.id,
+                producer_id: producer.id
+              }
+            end
+
+            subject { post :create, params }
+
+            it_behaves_like 'a successful request'
+
+            describe 'its body' do
+              before { post :create, params }
+
+              subject { JSON.parse(response.body) }
+
+              its(['group_id']) { is_expected.to eq(params[:group_id]) }
+              its(['producer_id']) { is_expected.to eq(params[:producer_id]) }
+            end
+
+            context 'with wrong parameters' do
+              let(:params) do
+                {
+                  group_id: 'hola',
+                  provider_id: 666
+                }
+              end
+
+              it_behaves_like 'a not found request'
+            end
+
+            xcontext 'when the producer is related to a user' do
+            end
+
+            context 'when the producer is related to a group' do
+              context 'and the user is an admin of the group' do
+                it_behaves_like 'a successful request'
+              end
+
+              context 'and the user is not an admin of the group' do
+                before do
+                  group_membership.role = ::Group::Membership::ROLES[:member]
+                  group_membership.save!
+                end
+
+                it_behaves_like 'a forbidden request'
+              end
+            end
+          end
+
+          describe 'DELETE #destroy' do
+            let(:supplier) do
+              FactoryGirl.create(
+                :supplier,
+                producer: producer,
+                group: group
+              )
+            end
+            let(:params) { { id: supplier.id } }
+
+            subject { delete :destroy, params }
+
+            context 'destroying a non existent supplier' do
+              let(:supplier) { instance_double(Supplier, id: 666) }
+
+              it_behaves_like 'a not found request'
+            end
+
+            xcontext 'destroying a supplier which producer is associated to a user' do
+            end
+
+            context 'destroying a supplier which producer is associated to a group' do
+              it_behaves_like 'a successful request (204)'
+
+              context 'when the user is not a group admin' do
+                before do
+                  group_membership.role = ::Group::Membership::ROLES[:member]
+                  group_membership.save!
+                end
+
+                it_behaves_like 'a forbidden request'
+              end
+            end
+
+            context 'destroying a supplier not associated to the current user' do
+              let(:suppliers_user) do
+                user = FactoryGirl.create(:user)
+                User.find(user.id)
+              end
+
+              it_behaves_like 'a forbidden request'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/engines/suppliers/spec/controllers/suppliers/api/v1/suppliers_controller_spec.rb
+++ b/engines/suppliers/spec/controllers/suppliers/api/v1/suppliers_controller_spec.rb
@@ -163,15 +163,40 @@ module Suppliers
               it_behaves_like 'a forbidden request'
             end
 
-            context 'with wrong parameters' do
+            context 'with wrong `producer_id` parameter' do
               let(:params) do
                 {
-                  group_id: 'hola',
-                  provider_id: 666
+                  group_id: 666,
+                  producer_id: producer.id
                 }
               end
 
               it_behaves_like 'a not found request'
+            end
+
+            context 'with wrong `producer_id` parameter' do
+              let(:params) do
+                {
+                  group_id: group.id,
+                  producer_id: 666
+                }
+              end
+
+              it_behaves_like 'a bad request'
+
+              describe 'its body' do
+                before { post :create, params }
+
+                subject { JSON.parse(response.body) }
+
+                it do
+                  is_expected.to include(
+                    'errors' => {
+                      'producer' => ["can't be blank"]
+                    }
+                  )
+                end
+              end
             end
           end
 

--- a/engines/suppliers/spec/policies/suppliers/group_policy_spec.rb
+++ b/engines/suppliers/spec/policies/suppliers/group_policy_spec.rb
@@ -11,7 +11,7 @@ module Suppliers
 
     subject { described_class }
 
-    permissions :create?, :update?, :destroy? do
+    permissions :update? do
       it 'is set to `false` by default' do
         expect(subject).to_not permit(instance_double(User), instance_double(Producer))
       end
@@ -19,11 +19,10 @@ module Suppliers
 
     permissions :show?, :index? do
       context 'when the user is associated to the group' do
-        let(:group_user) { ::BasicResources::User.find(user.id) }
         let!(:membership) do
           ::BasicResources::Membership.create(
             basic_resource_group_id: group.id,
-            user_id: group_user.id,
+            user_id: user.id,
             role: role
           )
         end
@@ -41,6 +40,34 @@ module Suppliers
 
           it 'grants access' do
             expect(subject).to permit(user, group)
+          end
+        end
+      end
+    end
+
+    permissions :create?, :destroy? do
+      context 'when the user is associated to the group' do
+        let!(:membership) do
+          ::BasicResources::Membership.create(
+            basic_resource_group_id: group.id,
+            user_id: user.id,
+            role: role
+          )
+        end
+
+        context 'as `admin`' do
+          let(:role) { Membership::ROLES[:admin] }
+
+          it 'grants access' do
+            expect(subject).to permit(user, group)
+          end
+        end
+
+        context 'as `member`' do
+          let(:role) { Membership::ROLES[:member] }
+
+          it 'denies access' do
+            expect(subject).to_not permit(user, group)
           end
         end
       end

--- a/engines/suppliers/spec/policies/suppliers/producer_policy_spec.rb
+++ b/engines/suppliers/spec/policies/suppliers/producer_policy_spec.rb
@@ -5,9 +5,18 @@ module Suppliers
   describe ProducerPolicy do
     subject { described_class }
 
-    permissions :create?, :update?, :destroy? do
+    permissions :update?, :destroy? do
       it 'is set to `false` by default' do
         expect(subject).to_not permit(instance_double(User), instance_double(Producer))
+      end
+    end
+
+    # You don't need permissions at Producer level to
+    # add a Producer as a Supplier to a Group, for now...
+    #
+    permissions :create? do
+      it 'grants access in any case' do
+        expect(subject).to permit(instance_double(User), instance_double(Producer))
       end
     end
 


### PR DESCRIPTION
```
GET /api/v1/suppliers?group_id=27
```
**Response body:** an array with all the suppliers related to the group with id `27`
**Status code:** `200`
**Permissions:** only admins and members of group with id 27 can perform this request
```
GET /api/v1/suppliers/2
```
**Response body:** the supplier with id `2`
**Status code:** `200`
**Permissions:** only admins and members of the group associated with the requested supplier can perform this request
```
POST /api/v1/suppliers
{
  group_id: 27,
  producer_id: 134
}
```
**Response body:** the created resource
**Status code:** `201`
**Permissions:** only admins of group with id `27` can perform this request
```
DELETE /api/v1/suppliers/2
```
**Response body:** empty body
**Status code:** `204`
**Permissions:** only admins and members of the group associated with the requested supplier can perform this request