### PR TITLE
Add orders frequency for groups

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ PATH
   remote: engines/suppliers
   specs:
     suppliers (0.0.1)
+      ice_cube (= 0.14.0)
       pg (= 0.18.3)
       rails (= 4.2.5)
 
@@ -111,6 +112,7 @@ GEM
     haml (4.0.7)
       tilt
     i18n (0.7.0)
+    ice_cube (0.14.0)
     json (1.8.3)
     kgio (2.10.0)
     loofah (2.0.3)
@@ -262,4 +264,4 @@ DEPENDENCIES
   unicorn (= 5.0.0)
 
 BUNDLED WITH
-   1.12.5
+   1.13.3

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161001134751) do
+ActiveRecord::Schema.define(version: 20161017174520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -114,6 +114,16 @@ ActiveRecord::Schema.define(version: 20161001134751) do
   add_index "orders", ["group_id"], name: "index_orders_on_group_id", using: :btree
   add_index "orders", ["user_id"], name: "index_orders_on_user_id", using: :btree
 
+  create_table "orders_frequencies", force: :cascade do |t|
+    t.integer  "group_id",       null: false
+    t.text     "frequency",      null: false
+    t.integer  "frequency_type", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "orders_frequencies", ["group_id", "frequency_type"], name: "index_orders_frequencies_on_group_id_and_frequency_type", unique: true, using: :btree
+
   create_table "producers", force: :cascade do |t|
     t.string   "name",       null: false
     t.string   "email",      null: false
@@ -163,6 +173,7 @@ ActiveRecord::Schema.define(version: 20161001134751) do
   add_foreign_key "memberships", "groups", name: "memberships_group_id_fkey"
   add_foreign_key "memberships", "producers", column: "basic_resource_producer_id", name: "memberships_basic_resource_producer_id_fkey"
   add_foreign_key "memberships", "users", name: "memberships_user_id_fkey"
+  add_foreign_key "orders_frequencies", "groups"
   add_foreign_key "products", "producers"
   add_foreign_key "suppliers", "groups"
   add_foreign_key "suppliers", "producers"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,7 @@
+require 'ice_cube'
+
 # Users
+puts 'Creating users...'
 
 joanin = ::Account::User.create!(
   email: 'joanin@katuma.org',
@@ -17,6 +20,7 @@ frida = ::Account::User.create!(
 )
 
 # Groups
+puts 'Creating groups...'
 
 tomatika = ::BasicResources::Group.create!(
   name: 'Tomatika'
@@ -45,6 +49,7 @@ cabas = ::BasicResources::Group.create!(
 )
 
 # Producers
+puts 'Creating producers...'
 
 jaume = ::BasicResources::Producer.new(
   name: 'El Jaume',
@@ -73,6 +78,7 @@ prueba = ::BasicResources::Producer.new(
 ).create!
 
 # Products
+puts 'Creating products...'
 
 ::Products::Product.create!(
   producer_id: jaume.id,
@@ -85,4 +91,25 @@ prueba = ::BasicResources::Producer.new(
   name: 'Bledas al manat',
   unit: ::Products::Product::UNITS[:pc],
   price: 1.85
+)
+
+# OrdersFrequencies
+puts 'Creating order_frequencies...'
+
+confirmation_schedule = IceCube::Schedule.new do |f|
+  f.add_recurrence_rule IceCube::Rule.weekly.day(:saturday)
+end
+::Suppliers::OrdersFrequency.create!(
+  group_id: tomatika.id,
+  ical: confirmation_schedule.to_ical,
+  frequency_type: ::Suppliers::OrdersFrequency::FREQUENCY_TYPES[:confirmation]
+)
+
+delivery_schedule = IceCube::Schedule.new do |f|
+  f.add_recurrence_rule IceCube::Rule.weekly.day(:wednesday)
+end
+::Suppliers::OrdersFrequency.create!(
+  group_id: tomatika.id,
+  ical: delivery_schedule.to_ical,
+  frequency_type: ::Suppliers::OrdersFrequency::FREQUENCY_TYPES[:delivery]
 )

--- a/engines/suppliers/Gemfile.lock
+++ b/engines/suppliers/Gemfile.lock
@@ -34,6 +34,7 @@ PATH
   remote: .
   specs:
     suppliers (0.0.1)
+      ice_cube (= 0.14.0)
       pg (= 0.18.3)
       rails (= 4.2.5)
 
@@ -92,6 +93,7 @@ GEM
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
+    ice_cube (0.14.0)
     json (1.8.3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -189,4 +191,4 @@ DEPENDENCIES
   suppliers!
 
 BUNDLED WITH
-   1.12.5
+   1.13.3

--- a/engines/suppliers/app/controllers/suppliers/api/v1/orders_frequencies_controller.rb
+++ b/engines/suppliers/app/controllers/suppliers/api/v1/orders_frequencies_controller.rb
@@ -1,0 +1,81 @@
+module Suppliers
+  module Api
+    module V1
+      class OrdersFrequenciesController < ApplicationController
+        before_action :authenticate
+        before_action :load_orders_frequency, only: [:show, :update]
+        before_action :load_group, only: [:index, :create]
+
+        # GET /api/v1/orders_frequencies?group_id=
+        #
+        # You must pass `group_id` param
+        #
+        def index
+          orders_frequencies = OrdersFrequency.where(group_id: @group.id)
+
+          render json: OrdersFrequenciesSerializer.new(orders_frequencies)
+        end
+
+        # GET /api/v1/orders_frequencies/:id
+        #
+        def show
+          render json: OrdersFrequencySerializer.new(@orders_frequency)
+        end
+
+        # POST /api/v1/orders_frequencies
+        #
+        def create
+          orders_frequency = OrdersFrequency.new(
+            group: @group,
+            ical: orders_frequency_params[:ical],
+            frequency_type: orders_frequency_params[:frequency_type]
+          )
+
+          if orders_frequency.save
+            render json: OrdersFrequencySerializer.new(orders_frequency)
+          else
+            render(
+              status: :bad_request,
+              json: { errors: orders_frequency.errors.messages }
+            )
+          end
+        end
+
+        # PUT /api/v1/orders_frequencies/:id
+        #
+        def update
+          if @orders_frequency.update_attributes(orders_frequency_params)
+            render json: OrdersFrequencySerializer.new(@orders_frequency)
+          else
+            render(
+              status: :bad_request,
+              json: { errors: @orders_frequency.errors.messages }
+            )
+          end
+        end
+
+        private
+
+        def orders_frequency_params
+          params.permit(:group_id, :ical, :frequency_type)
+        end
+
+        def load_orders_frequency
+          @orders_frequency = OrdersFrequency.find_by_id(params[:id])
+
+          return head :not_found unless @orders_frequency
+
+          authorize @orders_frequency.group
+        end
+
+        def load_group
+          @group = Group.find_by_id(orders_frequency_params[:group_id])
+
+          return head :not_found unless @group
+
+          authorize @group
+        end
+      end
+    end
+  end
+end

--- a/engines/suppliers/app/models/suppliers/group.rb
+++ b/engines/suppliers/app/models/suppliers/group.rb
@@ -9,5 +9,6 @@ module Suppliers
     has_many :producers,
       class_name: 'Suppliers::Producer'.freeze,
       through: :suppliers
+    has_one :orders_frequencies
   end
 end

--- a/engines/suppliers/app/models/suppliers/orders_frequency.rb
+++ b/engines/suppliers/app/models/suppliers/orders_frequency.rb
@@ -1,0 +1,32 @@
+require 'ice_cube'
+
+module Suppliers
+  class OrdersFrequency < ActiveRecord::Base
+    self.table_name = :orders_frequencies
+
+    FREQUENCY_TYPES = { confirmation: 0, delivery: 1 }.freeze
+
+    serialize :frequency, IceCube::Schedule
+
+    belongs_to :group
+
+    validates :group, :frequency, :frequency_type, presence: true
+    validates :frequency_type, inclusion: { in: FREQUENCY_TYPES.values }
+    validates :frequency_type, uniqueness: { scope: :group_id }
+
+    delegate :to_ical, to: :frequency
+
+    attr_accessor :ical
+
+    # TODO: better callback
+    #
+    # We can only store a `frequency` through `ical`
+    before_validation do
+      if ical.blank?
+        errors.add(:ical)
+      else
+        self.frequency = IceCube::Schedule.from_ical(ical)
+      end
+    end
+  end
+end

--- a/engines/suppliers/app/policies/suppliers/group_policy.rb
+++ b/engines/suppliers/app/policies/suppliers/group_policy.rb
@@ -21,7 +21,7 @@ module Suppliers
     end
 
     def update?
-      false
+      create?
     end
 
     def destroy?

--- a/engines/suppliers/app/serializers/suppliers/orders_frequencies_serializer.rb
+++ b/engines/suppliers/app/serializers/suppliers/orders_frequencies_serializer.rb
@@ -1,0 +1,9 @@
+module Suppliers
+  class OrdersFrequenciesSerializer < Shared::BaseSerializer
+    schema do
+      type 'orders_frequencies'
+
+      collection :orders_frequencies, item, OrdersFrequencySerializer
+    end
+  end
+end

--- a/engines/suppliers/app/serializers/suppliers/orders_frequency_serializer.rb
+++ b/engines/suppliers/app/serializers/suppliers/orders_frequency_serializer.rb
@@ -1,0 +1,9 @@
+module Suppliers
+  class OrdersFrequencySerializer < Shared::BaseSerializer
+    schema do
+      type 'orders_frequency'
+
+      map_properties :id, :group_id, :to_ical, :frequency_type, :created_at, :updated_at
+    end
+  end
+end

--- a/engines/suppliers/config/routes.rb
+++ b/engines/suppliers/config/routes.rb
@@ -3,6 +3,7 @@ Suppliers::Engine.routes.draw do
     namespace :v1 do
       resources :suppliers, except: [:new, :edit]
       resources :producers, only: [:index, :show]
+      resources :orders_frequencies, except: [:new, :edit, :destroy]
     end
   end
 end

--- a/engines/suppliers/db/migrate/20161017174520_create_orders_frequencies.rb
+++ b/engines/suppliers/db/migrate/20161017174520_create_orders_frequencies.rb
@@ -1,0 +1,13 @@
+class CreateOrdersFrequencies < ActiveRecord::Migration
+  def change
+    create_table :orders_frequencies do |t|
+      t.references :group, null: false, foreign_key: true, on_delete: :cascade
+      t.text :frequency, null: false
+      t.integer :frequency_type, null: false
+
+      t.timestamps
+    end
+
+    add_index :orders_frequencies, [:group_id, :frequency_type], unique: true
+  end
+end

--- a/engines/suppliers/spec/controllers/suppliers/api/v1/orders_frequencies_controller_spec.rb
+++ b/engines/suppliers/spec/controllers/suppliers/api/v1/orders_frequencies_controller_spec.rb
@@ -1,0 +1,352 @@
+require 'rails_helper'
+require_relative '../../../../../../../spec/support/shared_examples/controllers.rb'
+require_relative '../../../../../../../spec/support/authentication.rb'
+
+module Suppliers
+  module Api
+    module V1
+      describe OrdersFrequenciesController do
+        routes { Engine.routes }
+
+        context 'Not authenticaded user' do
+          describe 'GET #index' do
+            subject { get :index }
+
+            it_behaves_like 'an unauthorized request'
+          end
+
+          describe 'GET #show' do
+            subject { get :show, id: 666 }
+
+            it_behaves_like 'an unauthorized request'
+          end
+
+          describe 'POST #create' do
+            subject { post :create, name: 'ciola' }
+
+            it_behaves_like 'an unauthorized request'
+          end
+
+          describe 'PUT #update' do
+            subject { put :update, id: 666 }
+
+            it_behaves_like 'an unauthorized request'
+          end
+        end
+
+        context 'Authenticated user' do
+          let(:user) do
+            u = FactoryGirl.create(:user)
+            User.find(u.id)
+          end
+          let(:group) { FactoryGirl.create(:group) }
+          let!(:group_membership) do
+            FactoryGirl.create(
+              :membership,
+              basic_resource_group_id: group.id,
+              user_id: user.id,
+              role: ::BasicResources::Membership::ROLES[:admin]
+            )
+          end
+          let(:schedule) do
+            IceCube::Schedule.new do |f|
+              f.add_recurrence_rule IceCube::Rule.weekly
+            end
+          end
+          let(:confirmation_frequency) do
+            FactoryGirl.create(
+              :orders_frequency,
+              group_id: group.id,
+              ical: schedule.to_ical,
+              frequency_type: OrdersFrequency::FREQUENCY_TYPES[:confirmation]
+            )
+          end
+          let(:delivery_frequency) do
+            FactoryGirl.create(
+              :orders_frequency,
+              group_id: group.id,
+              ical: schedule.to_ical,
+              frequency_type: OrdersFrequency::FREQUENCY_TYPES[:delivery]
+            )
+          end
+
+          before { authenticate_as user }
+
+          describe 'GET #index' do
+            before { confirmation_frequency }
+            before { delivery_frequency }
+
+            subject { get :index, group_id: group_id }
+
+            context 'passing a `group_id` that does not exist' do
+              let(:group_id) { 666 }
+
+              it_behaves_like 'a not found request'
+            end
+
+            context 'passing a `group_id` of a group not associated to the user' do
+              let(:other_group) { FactoryGirl.create(:group) }
+              let(:group_id) { other_group.id }
+
+              it_behaves_like 'a forbidden request'
+            end
+
+            context 'passing a `group_id` of a group associated to the user' do
+              let(:group_id) { group.id }
+
+              it_behaves_like 'a successful request'
+
+              describe 'its body' do
+                before { get :index, group_id: group.id }
+
+                subject { JSON.parse(response.body) }
+
+                it do
+                  is_expected.to contain_exactly(
+                    match(
+                      'id' => confirmation_frequency.id,
+                      'group_id' => confirmation_frequency.group_id,
+                      'to_ical' => confirmation_frequency.to_ical,
+                      'frequency_type' => confirmation_frequency.frequency_type,
+                      'created_at' => confirmation_frequency.created_at.as_json,
+                      'updated_at' => confirmation_frequency.updated_at.as_json
+                    ),
+                    match(
+                      'id' => delivery_frequency.id,
+                      'group_id' => delivery_frequency.group_id,
+                      'to_ical' => delivery_frequency.to_ical,
+                      'frequency_type' => delivery_frequency.frequency_type,
+                      'created_at' => delivery_frequency.created_at.as_json,
+                      'updated_at' => delivery_frequency.updated_at.as_json
+                    )
+                  )
+                end
+              end
+            end
+          end
+
+          describe 'GET #show' do
+            before { confirmation_frequency }
+
+            subject { get :show, id: orders_frequency_id }
+
+            context 'requesting a non existent orders_frequency' do
+              let(:orders_frequency_id) { 666 }
+
+              it_behaves_like 'a not found request'
+            end
+
+            context 'requesting an existent orders_frequency' do
+              context 'when the user is associated to the group' do
+                let(:orders_frequency_id) { confirmation_frequency.id }
+
+                it_behaves_like 'a successful request'
+
+                describe 'its body' do
+                  before { get :show, id: orders_frequency_id }
+
+                  subject { JSON.parse(response.body) }
+
+                  it do
+                    is_expected.to match(
+                      'id' => confirmation_frequency.id,
+                      'group_id' => confirmation_frequency.group_id,
+                      'to_ical' => confirmation_frequency.to_ical,
+                      'frequency_type' => confirmation_frequency.frequency_type,
+                      'created_at' => confirmation_frequency.created_at.as_json,
+                      'updated_at' => confirmation_frequency.updated_at.as_json
+                    )
+                  end
+                end
+              end
+
+              context 'when the user is not associated to the group' do
+                let(:orders_frequency_id) { confirmation_frequency.id }
+
+                before { group_membership.destroy! }
+
+                it_behaves_like 'a forbidden request'
+              end
+            end
+          end
+
+          describe 'POST #create' do
+            let(:params) do
+              {
+                group_id: group.id,
+                ical: schedule.to_ical,
+                frequency_type: OrdersFrequency::FREQUENCY_TYPES[:delivery]
+              }
+            end
+
+            subject { post :create, params }
+
+            context 'when the user is associated to the group' do
+              context 'as an `admin`' do
+                it_behaves_like 'a successful request'
+
+                describe 'its body' do
+                  before { post :create, params }
+
+                  subject { JSON.parse(response.body) }
+
+                  it do
+                    is_expected.to include(
+                      'group_id' => params[:group_id],
+                      'to_ical' => params[:ical],
+                      'frequency_type' => params[:frequency_type]
+                    )
+                  end
+                end
+              end
+
+              context 'as a `member`' do
+                before do
+                  group_membership.role = ::BasicResources::Membership::ROLES[:member]
+                  group_membership.save!
+                end
+
+                it_behaves_like 'a forbidden request'
+              end
+            end
+
+            context 'when the user is not associated to the group' do
+              before { group_membership.destroy! }
+
+              it_behaves_like 'a forbidden request'
+            end
+
+            context 'with wrong `group_id` parameter' do
+              let(:params) do
+                {
+                  group_id: 666,
+                  to_ical: schedule.to_ical
+                }
+              end
+
+              it_behaves_like 'a not found request'
+            end
+
+            context 'with missing `to_ical` parameter' do
+              let(:params) do
+                {
+                  group_id: group.id
+                }
+              end
+
+              it_behaves_like 'a bad request'
+
+              describe 'its body' do
+                before { post :create, params }
+
+                subject { JSON.parse(response.body) }
+
+                it do
+                  is_expected.to match(
+                    'errors' => {
+                      'ical' => ['is invalid'],
+                      'frequency' => ["can't be blank"],
+                      'frequency_type' => ["can't be blank", 'is not included in the list']
+                    }
+                  )
+                end
+              end
+            end
+          end
+
+          describe 'PUT #update' do
+            let(:new_schedule) do
+              IceCube::Schedule.new do |f|
+                f.add_recurrence_rule IceCube::Rule.weekly.day(:tuesday)
+              end
+            end
+            let(:params) do
+              {
+                id: orders_frequency_id,
+                ical: new_schedule.to_ical
+              }
+            end
+
+            before { confirmation_frequency }
+
+            subject { put :update, params }
+
+            context 'updating a non existent orders_frequency' do
+              let(:orders_frequency_id) { 666 }
+
+              it_behaves_like 'a not found request'
+            end
+
+            context 'when the user is associated to the group' do
+              let(:orders_frequency_id) { confirmation_frequency.id }
+
+              context 'as an `admin`' do
+                context 'with valid parameters' do
+                  it_behaves_like 'a successful request'
+
+                  describe 'its body' do
+                    before { put :update, params }
+
+                    subject { JSON.parse(response.body) }
+
+                    it do
+                      is_expected.to include(
+                        'id' => confirmation_frequency.id,
+                        'group_id' => confirmation_frequency.group_id,
+                        'to_ical' => new_schedule.to_ical,
+                        'frequency_type' => confirmation_frequency.frequency_type,
+                        'created_at' => confirmation_frequency.created_at.as_json
+                      )
+                    end
+                  end
+                end
+
+                context 'with not valid parameters' do
+                  let(:params) do
+                    {
+                      id: orders_frequency_id,
+                      ical: ''
+                    }
+                  end
+
+                  it_behaves_like 'a bad request'
+
+                  describe 'its body' do
+                    before { put :update, params }
+
+                    subject { JSON.parse(response.body) }
+
+                    it do
+                      is_expected.to match(
+                        'errors' => {
+                          'ical' => ['is invalid']
+                        }
+                      )
+                    end
+                  end
+                end
+              end
+
+              context 'as a `member`' do
+                before do
+                  group_membership.role = ::BasicResources::Membership::ROLES[:member]
+                  group_membership.save!
+                end
+
+                it_behaves_like 'a forbidden request'
+              end
+            end
+
+            context 'when the user is not associated to the group' do
+              let(:orders_frequency_id) { confirmation_frequency.id }
+
+              before { group_membership.destroy! }
+
+              it_behaves_like 'a forbidden request'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/engines/suppliers/spec/dummy/db/schema.rb
+++ b/engines/suppliers/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161001134751) do
+ActiveRecord::Schema.define(version: 20161017174520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,16 @@ ActiveRecord::Schema.define(version: 20161001134751) do
 
   add_index "orders", ["group_id"], name: "index_orders_on_group_id", using: :btree
   add_index "orders", ["user_id"], name: "index_orders_on_user_id", using: :btree
+
+  create_table "orders_frequencies", force: :cascade do |t|
+    t.integer  "group_id",       null: false
+    t.text     "frequency",      null: false
+    t.integer  "frequency_type", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "orders_frequencies", ["group_id", "frequency_type"], name: "index_orders_frequencies_on_group_id_and_frequency_type", unique: true, using: :btree
 
   create_table "producers", force: :cascade do |t|
     t.string   "name",       null: false
@@ -109,6 +119,7 @@ ActiveRecord::Schema.define(version: 20161001134751) do
   add_foreign_key "memberships", "groups", name: "memberships_group_id_fkey"
   add_foreign_key "memberships", "producers", column: "basic_resource_producer_id", name: "memberships_basic_resource_producer_id_fkey"
   add_foreign_key "memberships", "users", name: "memberships_user_id_fkey"
+  add_foreign_key "orders_frequencies", "groups"
   add_foreign_key "products", "producers"
   add_foreign_key "suppliers", "groups"
   add_foreign_key "suppliers", "producers"

--- a/engines/suppliers/spec/factories.rb
+++ b/engines/suppliers/spec/factories.rb
@@ -1,4 +1,7 @@
 FactoryGirl.define do
   factory :supplier, class: Suppliers::Supplier do
   end
+
+  factory :orders_frequency, class: Suppliers::OrdersFrequency do
+  end
 end

--- a/engines/suppliers/spec/models/suppliers/orders_frequency_spec.rb
+++ b/engines/suppliers/spec/models/suppliers/orders_frequency_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+require 'ice_cube'
+
+module Suppliers
+  describe OrdersFrequency do
+    let(:group) { FactoryGirl.create(:group) }
+    let(:schedule) do
+      IceCube::Schedule.new do |f|
+        f.add_recurrence_rule IceCube::Rule.weekly
+      end
+    end
+
+    describe 'Validations' do
+      it 'has a valid factory' do
+        expect(
+          FactoryGirl.build(
+            :orders_frequency,
+            group_id: group.id,
+            ical: schedule.to_ical,
+            frequency_type: OrdersFrequency::FREQUENCY_TYPES[:confirmation]
+          )
+        ).to be_valid
+      end
+
+      it { is_expected.to validate_presence_of(:group) }
+      it { is_expected.to validate_presence_of(:frequency) }
+      it { is_expected.to validate_presence_of(:frequency_type) }
+      it do
+        is_expected.to validate_inclusion_of(:frequency_type)
+          .in_array(OrdersFrequency::FREQUENCY_TYPES.values)
+      end
+      describe 'validates uniqueness of `frequency_type` scoped to `group_id`' do
+        before do
+          FactoryGirl.create(
+            :orders_frequency,
+            group_id: group.id,
+            ical: schedule.to_ical,
+            frequency_type: OrdersFrequency::FREQUENCY_TYPES[:confirmation]
+          )
+        end
+
+        it { is_expected.to validate_uniqueness_of(:frequency_type).scoped_to(:group_id) }
+      end
+
+      context 'passing no `ical` attribute' do
+        let(:orders_frequency) do
+          FactoryGirl.build(
+            :orders_frequency,
+            group_id: group.id,
+            frequency_type: OrdersFrequency::FREQUENCY_TYPES[:confirmation]
+          )
+        end
+
+        before { orders_frequency.valid? }
+
+        subject { orders_frequency.errors.messages }
+
+        it do
+          is_expected.to match(
+            ical: ['is invalid'],
+            frequency: ["can't be blank"]
+          )
+        end
+      end
+    end
+
+    describe 'Associations' do
+      it { is_expected.to belong_to(:group) }
+    end
+
+    describe '#to_ical' do
+      let(:orders_frequency) do
+        FactoryGirl.create(
+          :orders_frequency,
+          group_id: group.id,
+          ical: schedule.to_ical,
+          frequency_type: OrdersFrequency::FREQUENCY_TYPES[:confirmation]
+        )
+      end
+
+      subject { orders_frequency.to_ical }
+
+      it { is_expected.to eq(orders_frequency.frequency.to_ical) }
+
+      context 'passing an `ical` attribute' do
+        let(:orders_frequency) do
+          FactoryGirl.create(
+            :orders_frequency,
+            group_id: group.id,
+            ical: schedule.to_ical,
+            frequency_type: OrdersFrequency::FREQUENCY_TYPES[:confirmation]
+          )
+        end
+
+        it { is_expected.to eq(schedule.to_ical) }
+      end
+    end
+  end
+end

--- a/engines/suppliers/spec/policies/suppliers/group_policy_spec.rb
+++ b/engines/suppliers/spec/policies/suppliers/group_policy_spec.rb
@@ -11,12 +11,6 @@ module Suppliers
 
     subject { described_class }
 
-    permissions :update? do
-      it 'is set to `false` by default' do
-        expect(subject).to_not permit(instance_double(User), instance_double(Producer))
-      end
-    end
-
     permissions :show?, :index? do
       context 'when the user is associated to the group' do
         let!(:membership) do
@@ -45,7 +39,7 @@ module Suppliers
       end
     end
 
-    permissions :create?, :destroy? do
+    permissions :create?, :update?, :destroy? do
       context 'when the user is associated to the group' do
         let!(:membership) do
           ::BasicResources::Membership.create(

--- a/engines/suppliers/spec/serializers/suppliers/orders_frequencies_serializer_spec.rb
+++ b/engines/suppliers/spec/serializers/suppliers/orders_frequencies_serializer_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+module Suppliers
+  describe OrdersFrequenciesSerializer do
+    let(:schedule) do
+      IceCube::Schedule.new do |f|
+        f.add_recurrence_rule IceCube::Rule.weekly
+      end
+    end
+    let(:orders_frequency) do
+      instance_double(
+        OrdersFrequency,
+        id: 13,
+        group_id: 666,
+        to_ical: schedule.to_ical,
+        frequency_type: OrdersFrequency::FREQUENCY_TYPES[:confirmation],
+        created_at: Time.now.utc,
+        updated_at: Time.now.utc
+      )
+    end
+    let(:orders_frequency_attributes) do
+      {
+        id: orders_frequency.id,
+        group_id: orders_frequency.group_id,
+        to_ical: schedule.to_ical,
+        frequency_type: orders_frequency.frequency_type,
+        created_at: orders_frequency.created_at,
+        updated_at: orders_frequency.updated_at
+      }
+    end
+
+    subject { described_class.new([orders_frequency]).to_hash }
+
+    it do
+      is_expected.to contain_exactly(
+        match(orders_frequency_attributes)
+      )
+    end
+  end
+end

--- a/engines/suppliers/spec/serializers/suppliers/orders_frequency_serializer_spec.rb
+++ b/engines/suppliers/spec/serializers/suppliers/orders_frequency_serializer_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+module Suppliers
+  describe OrdersFrequencySerializer do
+    let(:group) { FactoryGirl.create(:group) }
+    let(:schedule) do
+      IceCube::Schedule.new do |f|
+        f.add_recurrence_rule IceCube::Rule.weekly
+      end
+    end
+    let(:orders_frequency) do
+      FactoryGirl.create(
+        :orders_frequency,
+        group_id: group.id,
+        ical: schedule.to_ical,
+        frequency_type: OrdersFrequency::FREQUENCY_TYPES[:confirmation]
+      )
+    end
+    let(:attributes) do
+      {
+        id: orders_frequency.id,
+        group_id: orders_frequency.group_id,
+        to_ical: schedule.to_ical,
+        frequency_type: orders_frequency.frequency_type,
+        created_at: orders_frequency.created_at,
+        updated_at: orders_frequency.updated_at
+      }
+    end
+
+    subject { described_class.new(orders_frequency).to_hash }
+
+    it { is_expected.to match(attributes) }
+  end
+end

--- a/engines/suppliers/suppliers.gemspec
+++ b/engines/suppliers/suppliers.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '4.2.5'
   s.add_dependency 'pg', '0.18.3'
+  s.add_dependency 'ice_cube', '0.14.0'
 
   s.add_development_dependency 'rspec-rails', '3.5.0'
   s.add_development_dependency 'byebug', '9.0.5'


### PR DESCRIPTION
When we generate a new order for a user and a group we need to set an "expiration date" since generally groups have a specific date to receive orders from the users and be able to commit the orders to the suppliers.

This could be for instance "every saturday at 7PM". With this PR we create a new resource where we store the recurrency information for each group.

#### TODO
 - [x] `PUT` action